### PR TITLE
Maven license plugin

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-© 2017 EntIT Software LLC, a Micro Focus company, L.P.
+Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pom.xml
+++ b/pom.xml
@@ -166,19 +166,20 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-    <build>
 
+    <build>
+        <!-- License headers are checked during the verify phase, the build will fail if a file is missing the header. -->
+        <!-- To fix license errors, use the following commands on the root pom. -->
+        <!-- mvn com.mycila:license-maven-plugin:format (add headers if missing) -->
+        <!-- mvn com.mycila:license-maven-plugin:remove (remove existing header) -->
         <plugins>
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <version>3.0</version>
                 <configuration>
+                    <!-- Update this file accordingly to change the license everywhere -->
                     <header>LICENSE.txt</header>
-                    <properties>
-                        <owner></owner>
-                        <email></email>
-                    </properties>
                     <excludes>
                         <exclude>README.MD</exclude>
                         <exclude>.gitignore</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <packaging>pom</packaging>
     <version>12.60.35-SNAPSHOT</version>
 
-    <name>HPE ALM Octane REST API SDK</name>
+    <name>ALM Octane REST API SDK</name>
     <description>The Java SDK that can be used to access Octane's REST API without worrying about REST or HTTP
     </description>
     <url>https://github.com/MicroFocus/ALMOctaneJavaRESTSDK</url>
@@ -43,15 +43,15 @@
     </scm>
 
     <organization>
-        <name>Hewlett Packard Enterprise</name>
-        <url>http://www.hpe.com</url>
+        <name>Micro Focus</name>
+        <url>http://www.microfocus.com</url>
     </organization>
 
     <developers>
         <developer>
             <name>Spencer Bruce</name>
-            <email>spencerbruce@hpe.com</email>
-            <organization>HPE</organization>
+            <email>spencerbruce@microfocus.com</email>
+            <organization>Micro Focus</organization>
         </developer>
     </developers>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,9 @@
                         <exclude>README.MD</exclude>
                         <exclude>.gitignore</exclude>
                         <exclude>.LICENSE.txt</exclude>
+                        <exclude>*.html</exclude>
+                        <exclude>*.vm</exclude>
+                        <exclude>*.properties</exclude>
                         <exclude>**/src/test/resources/**</exclude>
                         <exclude>***/src/main/resources/**</exclude>
                     </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -1,19 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -182,6 +167,36 @@
         </dependencies>
     </dependencyManagement>
     <build>
+
+        <plugins>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>3.0</version>
+                <configuration>
+                    <header>LICENSE.txt</header>
+                    <properties>
+                        <owner></owner>
+                        <email></email>
+                    </properties>
+                    <excludes>
+                        <exclude>README.MD</exclude>
+                        <exclude>.gitignore</exclude>
+                        <exclude>.LICENSE.txt</exclude>
+                        <exclude>**/src/test/resources/**</exclude>
+                        <exclude>***/src/main/resources/**</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+
         <pluginManagement>
             <plugins>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -184,12 +184,17 @@
                         <exclude>README.MD</exclude>
                         <exclude>.gitignore</exclude>
                         <exclude>.LICENSE.txt</exclude>
-                        <exclude>*.html</exclude>
-                        <exclude>*.vm</exclude>
-                        <exclude>*.properties</exclude>
+                        <exclude>**/**.html</exclude>
+                        <exclude>**/**.vm</exclude>
+                        <exclude>**/**.properties</exclude>
                         <exclude>**/src/test/resources/**</exclude>
                         <exclude>***/src/main/resources/**</exclude>
                     </excludes>
+                    <mapping>
+                        <!--Do not use javadoc comments for .java files, use only /* -->
+                        <!--Not sure why that's the default.-->
+                        <java>SLASHSTAR_STYLE</java>
+                    </mapping>
                 </configuration>
                 <executions>
                     <execution>

--- a/sdk-extension/pom.xml
+++ b/sdk-extension/pom.xml
@@ -28,7 +28,7 @@
     <artifactId>sdk-extension-root</artifactId>
     <packaging>pom</packaging>
 
-    <name>HPE ALM Octane REST API SDK Extension</name>
+    <name>ALM Octane REST API SDK Extension</name>
     <description>
         Extension of ALM Octane Java REST SDK, can be used for more advanced use cases.
     </description>

--- a/sdk-extension/pom.xml
+++ b/sdk-extension/pom.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/sdk-extension/pom.xml
+++ b/sdk-extension/pom.xml
@@ -1,19 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/sdk-extension/sdk-extension-src/pom.xml
+++ b/sdk-extension/sdk-extension-src/pom.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/sdk-extension/sdk-extension-src/pom.xml
+++ b/sdk-extension/sdk-extension-src/pom.xml
@@ -1,19 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/ExtendedOctaneClassFactory.java
+++ b/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/ExtendedOctaneClassFactory.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.extension;
 
 import com.hpe.adm.nga.sdk.OctaneClassFactory;

--- a/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/ExtendedOctaneClassFactory.java
+++ b/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/ExtendedOctaneClassFactory.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.extension;
 
 import com.hpe.adm.nga.sdk.OctaneClassFactory;

--- a/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/OctaneExtensionUtil.java
+++ b/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/OctaneExtensionUtil.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.extension;
 
 import com.hpe.adm.nga.sdk.OctaneClassFactory;

--- a/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/StringQuery.java
+++ b/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/StringQuery.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.extension;
 
 import com.hpe.adm.nga.sdk.query.Query;

--- a/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/StringQuery.java
+++ b/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/StringQuery.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.extension;
 
 import com.hpe.adm.nga.sdk.query.Query;

--- a/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/entities/ExtendedEntityList.java
+++ b/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/entities/ExtendedEntityList.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.extension.entities;
 
 import com.hpe.adm.nga.sdk.entities.EntityList;

--- a/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/entities/ExtendedEntityList.java
+++ b/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/entities/ExtendedEntityList.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.extension.entities;
 
 import com.hpe.adm.nga.sdk.entities.EntityList;

--- a/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/entities/ExtendedGetEntities.java
+++ b/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/entities/ExtendedGetEntities.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.extension.entities;
 
 import com.hpe.adm.nga.sdk.entities.get.GetEntities;

--- a/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/entities/ExtendedGetEntities.java
+++ b/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/entities/ExtendedGetEntities.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.extension.entities;
 
 import com.hpe.adm.nga.sdk.entities.get.GetEntities;

--- a/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/network/RequestInterceptor.java
+++ b/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/network/RequestInterceptor.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.extension.network;
 
 import java.util.Map;

--- a/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/network/RequestInterceptor.java
+++ b/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/network/RequestInterceptor.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.extension.network;
 
 import java.util.Map;

--- a/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/network/ResponseInterceptor.java
+++ b/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/network/ResponseInterceptor.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.extension.network;
 
 import java.util.Map;

--- a/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/network/ResponseInterceptor.java
+++ b/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/network/ResponseInterceptor.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.extension.network;
 
 import java.util.Map;

--- a/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/network/google/InterceptorGoogleHttpClient.java
+++ b/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/network/google/InterceptorGoogleHttpClient.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.extension.network.google;
 
 

--- a/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/network/google/InterceptorGoogleHttpClient.java
+++ b/sdk-extension/sdk-extension-src/src/main/java/com/hpe/adm/nga/sdk/extension/network/google/InterceptorGoogleHttpClient.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.extension.network.google;
 
 

--- a/sdk-extension/sdk-extension-usage-examples/pom.xml
+++ b/sdk-extension/sdk-extension-usage-examples/pom.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/sdk-extension/sdk-extension-usage-examples/pom.xml
+++ b/sdk-extension/sdk-extension-usage-examples/pom.xml
@@ -1,19 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/sdk-extension/sdk-extension-usage-examples/src/main/java/com/hpe/adm/nga/sdk/extension/GetExpandQueryExample.java
+++ b/sdk-extension/sdk-extension-usage-examples/src/main/java/com/hpe/adm/nga/sdk/extension/GetExpandQueryExample.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.extension;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-extension/sdk-extension-usage-examples/src/main/java/com/hpe/adm/nga/sdk/extension/GetExpandQueryExample.java
+++ b/sdk-extension/sdk-extension-usage-examples/src/main/java/com/hpe/adm/nga/sdk/extension/GetExpandQueryExample.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.extension;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-extension/sdk-extension-usage-examples/src/main/java/com/hpe/adm/nga/sdk/extension/OctaneConnectionConstants.java
+++ b/sdk-extension/sdk-extension-usage-examples/src/main/java/com/hpe/adm/nga/sdk/extension/OctaneConnectionConstants.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.extension;
 
 /**

--- a/sdk-extension/sdk-extension-usage-examples/src/main/java/com/hpe/adm/nga/sdk/extension/OctaneConnectionConstants.java
+++ b/sdk-extension/sdk-extension-usage-examples/src/main/java/com/hpe/adm/nga/sdk/extension/OctaneConnectionConstants.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.extension;
 
 /**

--- a/sdk-extension/sdk-extension-usage-examples/src/main/java/com/hpe/adm/nga/sdk/extension/Util.java
+++ b/sdk-extension/sdk-extension-usage-examples/src/main/java/com/hpe/adm/nga/sdk/extension/Util.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.extension;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-extension/sdk-extension-usage-examples/src/main/java/com/hpe/adm/nga/sdk/extension/Util.java
+++ b/sdk-extension/sdk-extension-usage-examples/src/main/java/com/hpe/adm/nga/sdk/extension/Util.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.extension;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-extension/sdk-extension-usage-examples/src/main/java/com/hpe/adm/nga/sdk/extension/interceptor/InterceptorExample.java
+++ b/sdk-extension/sdk-extension-usage-examples/src/main/java/com/hpe/adm/nga/sdk/extension/interceptor/InterceptorExample.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.extension.interceptor;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-extension/sdk-extension-usage-examples/src/main/java/com/hpe/adm/nga/sdk/extension/interceptor/InterceptorExample.java
+++ b/sdk-extension/sdk-extension-usage-examples/src/main/java/com/hpe/adm/nga/sdk/extension/interceptor/InterceptorExample.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.extension.interceptor;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-extension/sdk-extension-usage-examples/src/main/java/com/hpe/adm/nga/sdk/extension/stringquery/StringQueryExample.java
+++ b/sdk-extension/sdk-extension-usage-examples/src/main/java/com/hpe/adm/nga/sdk/extension/stringquery/StringQueryExample.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.extension.stringquery;
 
 

--- a/sdk-extension/sdk-extension-usage-examples/src/main/java/com/hpe/adm/nga/sdk/extension/stringquery/StringQueryExample.java
+++ b/sdk-extension/sdk-extension-usage-examples/src/main/java/com/hpe/adm/nga/sdk/extension/stringquery/StringQueryExample.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.extension.stringquery;
 
 

--- a/sdk-generate-entity-models-maven-plugin/pom.xml
+++ b/sdk-generate-entity-models-maven-plugin/pom.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/sdk-generate-entity-models-maven-plugin/src/main/java/com/hpe/adm/nga/sdk/generate/GenerateModels.java
+++ b/sdk-generate-entity-models-maven-plugin/src/main/java/com/hpe/adm/nga/sdk/generate/GenerateModels.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.generate;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-generate-entity-models-maven-plugin/src/main/java/com/hpe/adm/nga/sdk/generate/GenerateModels.java
+++ b/sdk-generate-entity-models-maven-plugin/src/main/java/com/hpe/adm/nga/sdk/generate/GenerateModels.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.generate;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-generate-entity-models-maven-plugin/src/main/java/com/hpe/adm/nga/sdk/generate/GenerateModelsPlugin.java
+++ b/sdk-generate-entity-models-maven-plugin/src/main/java/com/hpe/adm/nga/sdk/generate/GenerateModelsPlugin.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.generate;
 
 import org.apache.maven.plugin.AbstractMojo;

--- a/sdk-generate-entity-models-maven-plugin/src/main/java/com/hpe/adm/nga/sdk/generate/GenerateModelsPlugin.java
+++ b/sdk-generate-entity-models-maven-plugin/src/main/java/com/hpe/adm/nga/sdk/generate/GenerateModelsPlugin.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.generate;
 
 import org.apache.maven.plugin.AbstractMojo;

--- a/sdk-generate-entity-models-maven-plugin/src/main/java/com/hpe/adm/nga/sdk/generate/GeneratorHelper.java
+++ b/sdk-generate-entity-models-maven-plugin/src/main/java/com/hpe/adm/nga/sdk/generate/GeneratorHelper.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.generate;
 
 import com.hpe.adm.nga.sdk.metadata.EntityMetadata;

--- a/sdk-generate-entity-models-maven-plugin/src/main/java/com/hpe/adm/nga/sdk/generate/GeneratorHelper.java
+++ b/sdk-generate-entity-models-maven-plugin/src/main/java/com/hpe/adm/nga/sdk/generate/GeneratorHelper.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.generate;
 
 import com.hpe.adm.nga.sdk.metadata.EntityMetadata;

--- a/sdk-generate-entity-models-maven-plugin/src/main/resources/Entity.vm
+++ b/sdk-generate-entity-models-maven-plugin/src/main/resources/Entity.vm
@@ -1,17 +1,3 @@
-############################################################################
-## Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##   http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
-############################################################################
 package com.hpe.adm.nga.sdk.model;
 
 interface ${interfaceName} extends ${superInterfaceName} {}

--- a/sdk-generate-entity-models-maven-plugin/src/main/resources/EntityModel.vm
+++ b/sdk-generate-entity-models-maven-plugin/src/main/resources/EntityModel.vm
@@ -1,17 +1,3 @@
-############################################################################
-## Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##   http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
-############################################################################
 #set ($className = ${GeneratorHelper.camelCaseFieldName(${entityMetadata.name})})
 #set ($subTypeOf = ${GeneratorHelper.getSubTypeOf(${entityMetadata})})
 package com.hpe.adm.nga.sdk.model;

--- a/sdk-generate-entity-models-maven-plugin/src/main/resources/Lists.vm
+++ b/sdk-generate-entity-models-maven-plugin/src/main/resources/Lists.vm
@@ -1,17 +1,3 @@
-############################################################################
-## Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##   http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
-############################################################################
 package com.hpe.adm.nga.sdk.enums;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-generate-entity-models-maven-plugin/src/main/resources/Phases.vm
+++ b/sdk-generate-entity-models-maven-plugin/src/main/resources/Phases.vm
@@ -1,17 +1,3 @@
-############################################################################
-## Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##   http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
-############################################################################
 package com.hpe.adm.nga.sdk.enums;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-generate-entity-models-maven-plugin/src/main/resources/TypedEntityList.vm
+++ b/sdk-generate-entity-models-maven-plugin/src/main/resources/TypedEntityList.vm
@@ -1,17 +1,3 @@
-############################################################################
-## Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##   http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
-############################################################################
 package com.hpe.adm.nga.sdk.entities;
 
 import com.hpe.adm.nga.sdk.entities.create.CreateTypedEntities;

--- a/sdk-integration-tests/pom.xml
+++ b/sdk-integration-tests/pom.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/sdk-integration-tests/pom.xml
+++ b/sdk-integration-tests/pom.xml
@@ -1,19 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/TestTimeZoneConversion.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/TestTimeZoneConversion.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.tests;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/TestTimeZoneConversion.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/TestTimeZoneConversion.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.tests;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/attachments/TestAttachments.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/attachments/TestAttachments.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.tests.attachments;
 
 import com.google.common.io.ByteStreams;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/attachments/TestAttachments.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/attachments/TestAttachments.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.tests.attachments;
 
 import com.google.common.io.ByteStreams;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/authentication/TestAuthentication.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/authentication/TestAuthentication.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.tests.authentication;
 
 import com.hpe.adm.nga.sdk.exception.OctaneException;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/authentication/TestAuthentication.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/authentication/TestAuthentication.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.tests.authentication;
 
 import com.hpe.adm.nga.sdk.exception.OctaneException;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/base/TestBase.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/base/TestBase.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.tests.base;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/base/TestBase.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/base/TestBase.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.tests.base;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/comments/TestComments.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/comments/TestComments.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.tests.comments;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/comments/TestComments.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/comments/TestComments.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.tests.comments;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/context/TestSwitchContext.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/context/TestSwitchContext.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.tests.context;
 
 

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/context/TestSwitchContext.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/context/TestSwitchContext.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.tests.context;
 
 

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/cookieupdate/TestCookieUpdate.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/cookieupdate/TestCookieUpdate.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.tests.cookieupdate;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/cookieupdate/TestCookieUpdate.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/cookieupdate/TestCookieUpdate.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.tests.cookieupdate;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/crud/TestCreateEntity.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/crud/TestCreateEntity.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.tests.crud;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/crud/TestCreateEntity.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/crud/TestCreateEntity.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.tests.crud;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/crud/TestDeleteEntity.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/crud/TestDeleteEntity.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.tests.crud;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/crud/TestDeleteEntity.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/crud/TestDeleteEntity.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.tests.crud;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/crud/TestUpdateEntity.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/crud/TestUpdateEntity.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.tests.crud;
 
 import com.hpe.adm.nga.sdk.model.DateFieldModel;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/crud/TestUpdateEntity.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/crud/TestUpdateEntity.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.tests.crud;
 
 import com.hpe.adm.nga.sdk.model.DateFieldModel;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/errrohandling/TestOctaneException.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/errrohandling/TestOctaneException.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.tests.errrohandling;
 
 import com.hpe.adm.nga.sdk.exception.OctaneException;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/errrohandling/TestOctaneException.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/errrohandling/TestOctaneException.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.tests.errrohandling;
 
 import com.hpe.adm.nga.sdk.exception.OctaneException;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/filtering/TestCrossFiltering.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/filtering/TestCrossFiltering.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.tests.filtering;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/filtering/TestCrossFiltering.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/filtering/TestCrossFiltering.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.tests.filtering;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/filtering/TestFieldsFilter.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/filtering/TestFieldsFilter.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.tests.filtering;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/filtering/TestFieldsFilter.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/filtering/TestFieldsFilter.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.tests.filtering;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/filtering/TestLimit.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/filtering/TestLimit.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.tests.filtering;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/filtering/TestLimit.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/filtering/TestLimit.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.tests.filtering;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/filtering/TestLogicalOperators.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/filtering/TestLogicalOperators.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.tests.filtering;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/filtering/TestLogicalOperators.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/filtering/TestLogicalOperators.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.tests.filtering;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/filtering/TestSupportFiltering.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/filtering/TestSupportFiltering.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.tests.filtering;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/filtering/TestSupportFiltering.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/filtering/TestSupportFiltering.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.tests.filtering;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/metadata/TestReadMetadata.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/metadata/TestReadMetadata.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.tests.metadata;
 
 import com.hpe.adm.nga.sdk.metadata.EntityMetadata;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/metadata/TestReadMetadata.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/metadata/TestReadMetadata.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.tests.metadata;
 
 import com.hpe.adm.nga.sdk.metadata.EntityMetadata;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/orderby/TestOrderBy.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/orderby/TestOrderBy.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.tests.orderby;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/orderby/TestOrderBy.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/orderby/TestOrderBy.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.tests.orderby;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/parallelexecution/TestParallelExecution.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/parallelexecution/TestParallelExecution.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.tests.parallelexecution;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/parallelexecution/TestParallelExecution.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/parallelexecution/TestParallelExecution.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.tests.parallelexecution;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/sandbox/Demo.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/sandbox/Demo.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.tests.sandbox;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/sandbox/Demo.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/tests/sandbox/Demo.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.tests.sandbox;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/AuthenticationUtils.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/AuthenticationUtils.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.utils;
 
 import com.hpe.adm.nga.sdk.authentication.Authentication;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/AuthenticationUtils.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/AuthenticationUtils.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.utils;
 
 import com.hpe.adm.nga.sdk.authentication.Authentication;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/CommonUtils.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/CommonUtils.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.utils;
 
 import com.hpe.adm.nga.sdk.model.*;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/CommonUtils.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/CommonUtils.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.utils;
 
 import com.hpe.adm.nga.sdk.model.*;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/ConfigurationUtils.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/ConfigurationUtils.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.utils;
 
 import org.apache.commons.configuration2.CombinedConfiguration;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/ConfigurationUtils.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/ConfigurationUtils.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.utils;
 
 import org.apache.commons.configuration2.CombinedConfiguration;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/ContextUtils.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/ContextUtils.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.utils;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/ContextUtils.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/ContextUtils.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.utils;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/HttpUtils.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/HttpUtils.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.utils;
 
 import java.net.Socket;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/HttpUtils.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/HttpUtils.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.utils;
 
 import java.net.Socket;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/QueryUtils.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/QueryUtils.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.utils;
 
 import com.hpe.adm.nga.sdk.query.Query;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/QueryUtils.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/QueryUtils.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.utils;
 
 import com.hpe.adm.nga.sdk.query.Query;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/generator/DataGenerator.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/generator/DataGenerator.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.utils.generator;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/generator/DataGenerator.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/generator/DataGenerator.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.utils.generator;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-src/pom.xml
+++ b/sdk-src/pom.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/sdk-src/pom.xml
+++ b/sdk-src/pom.xml
@@ -1,19 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/DefaultOctaneClassFactory.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/DefaultOctaneClassFactory.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk;
 
 import com.hpe.adm.nga.sdk.entities.EntityList;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/DefaultOctaneClassFactory.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/DefaultOctaneClassFactory.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk;
 
 import com.hpe.adm.nga.sdk.entities.EntityList;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/Octane.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/Octane.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk;
 
 import com.hpe.adm.nga.sdk.attachments.AttachmentList;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/Octane.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/Octane.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk;
 
 import com.hpe.adm.nga.sdk.attachments.AttachmentList;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/OctaneClassFactory.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/OctaneClassFactory.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk;
 
 import com.hpe.adm.nga.sdk.entities.EntityList;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/OctaneClassFactory.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/OctaneClassFactory.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk;
 
 import com.hpe.adm.nga.sdk.entities.EntityList;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/attachments/AttachmentList.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/attachments/AttachmentList.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.attachments;
 
 import com.hpe.adm.nga.sdk.OctaneClassFactory;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/attachments/AttachmentList.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/attachments/AttachmentList.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.attachments;
 
 import com.hpe.adm.nga.sdk.OctaneClassFactory;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/attachments/CreateAttachment.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/attachments/CreateAttachment.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.attachments;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/attachments/CreateAttachment.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/attachments/CreateAttachment.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.attachments;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/attachments/GetBinaryAttachment.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/attachments/GetBinaryAttachment.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.attachments;
 
 import com.hpe.adm.nga.sdk.network.OctaneHttpClient;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/attachments/GetBinaryAttachment.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/attachments/GetBinaryAttachment.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.attachments;
 
 import com.hpe.adm.nga.sdk.network.OctaneHttpClient;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/authentication/Authentication.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/authentication/Authentication.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.authentication;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/authentication/Authentication.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/authentication/Authentication.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.authentication;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/authentication/ClientAuthentication.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/authentication/ClientAuthentication.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.authentication;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/authentication/ClientAuthentication.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/authentication/ClientAuthentication.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.authentication;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/authentication/SimpleClientAuthentication.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/authentication/SimpleClientAuthentication.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.authentication;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/authentication/SimpleClientAuthentication.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/authentication/SimpleClientAuthentication.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.authentication;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/authentication/SimpleUserAuthentication.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/authentication/SimpleUserAuthentication.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.authentication;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/authentication/SimpleUserAuthentication.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/authentication/SimpleUserAuthentication.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.authentication;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/authentication/UserAuthentication.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/authentication/UserAuthentication.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.authentication;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/authentication/UserAuthentication.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/authentication/UserAuthentication.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.authentication;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/EntityList.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/EntityList.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.entities;
 
 import com.hpe.adm.nga.sdk.entities.create.CreateEntities;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/EntityList.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/EntityList.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.entities;
 
 import com.hpe.adm.nga.sdk.entities.create.CreateEntities;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/OctaneCollection.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/OctaneCollection.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.entities;
 
 import com.hpe.adm.nga.sdk.model.Entity;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/OctaneCollection.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/OctaneCollection.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.entities;
 
 import com.hpe.adm.nga.sdk.model.Entity;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/TypedEntityList.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/TypedEntityList.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.entities;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/TypedEntityList.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/TypedEntityList.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.entities;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/create/CreateEntities.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/create/CreateEntities.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.entities.create;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/create/CreateEntities.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/create/CreateEntities.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.entities.create;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/create/CreateHelper.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/create/CreateHelper.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.entities.create;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/create/CreateHelper.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/create/CreateHelper.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.entities.create;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/create/CreateTypedEntities.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/create/CreateTypedEntities.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.entities.create;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/create/CreateTypedEntities.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/create/CreateTypedEntities.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.entities.create;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/delete/DeleteEntities.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/delete/DeleteEntities.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.entities.delete;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/delete/DeleteEntities.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/delete/DeleteEntities.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.entities.delete;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/delete/DeleteEntity.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/delete/DeleteEntity.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.entities.delete;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/delete/DeleteEntity.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/delete/DeleteEntity.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.entities.delete;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/delete/DeleteHelper.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/delete/DeleteHelper.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.entities.delete;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/delete/DeleteHelper.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/delete/DeleteHelper.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.entities.delete;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/delete/DeleteTypedEntities.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/delete/DeleteTypedEntities.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.entities.delete;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/delete/DeleteTypedEntities.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/delete/DeleteTypedEntities.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.entities.delete;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/delete/DeleteTypedEntity.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/delete/DeleteTypedEntity.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.entities.delete;
 
 import com.hpe.adm.nga.sdk.entities.TypedEntityList;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/delete/DeleteTypedEntity.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/delete/DeleteTypedEntity.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.entities.delete;
 
 import com.hpe.adm.nga.sdk.entities.TypedEntityList;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/get/GetEntities.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/get/GetEntities.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.entities.get;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/get/GetEntities.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/get/GetEntities.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.entities.get;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/get/GetEntity.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/get/GetEntity.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.entities.get;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/get/GetEntity.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/get/GetEntity.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.entities.get;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/get/GetHelper.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/get/GetHelper.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.entities.get;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/get/GetHelper.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/get/GetHelper.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.entities.get;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/get/GetTypedEntities.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/get/GetTypedEntities.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.entities.get;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/get/GetTypedEntities.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/get/GetTypedEntities.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.entities.get;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/get/GetTypedEntity.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/get/GetTypedEntity.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.entities.get;
 
 import com.hpe.adm.nga.sdk.entities.TypedEntityList;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/get/GetTypedEntity.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/get/GetTypedEntity.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.entities.get;
 
 import com.hpe.adm.nga.sdk.entities.TypedEntityList;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/get/GetTypedHelper.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/get/GetTypedHelper.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.entities.get;
 
 import com.hpe.adm.nga.sdk.entities.TypedEntityList;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/get/GetTypedHelper.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/get/GetTypedHelper.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.entities.get;
 
 import com.hpe.adm.nga.sdk.entities.TypedEntityList;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/update/UpdateEntities.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/update/UpdateEntities.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.entities.update;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/update/UpdateEntities.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/update/UpdateEntities.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.entities.update;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/update/UpdateEntity.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/update/UpdateEntity.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.entities.update;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/update/UpdateEntity.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/update/UpdateEntity.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.entities.update;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/update/UpdateHelper.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/update/UpdateHelper.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.entities.update;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/update/UpdateHelper.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/update/UpdateHelper.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.entities.update;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/update/UpdateTypedEntities.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/update/UpdateTypedEntities.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.entities.update;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/update/UpdateTypedEntities.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/update/UpdateTypedEntities.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.entities.update;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/update/UpdateTypedEntity.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/update/UpdateTypedEntity.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.entities.update;
 
 import com.hpe.adm.nga.sdk.entities.TypedEntityList;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/update/UpdateTypedEntity.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/update/UpdateTypedEntity.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.entities.update;
 
 import com.hpe.adm.nga.sdk.entities.TypedEntityList;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/exception/OctaneException.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/exception/OctaneException.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.exception;
 
 import com.hpe.adm.nga.sdk.model.ErrorModel;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/exception/OctaneException.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/exception/OctaneException.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.exception;
 
 import com.hpe.adm.nga.sdk.model.ErrorModel;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/exception/OctanePartialException.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/exception/OctanePartialException.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.exception;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/exception/OctanePartialException.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/exception/OctanePartialException.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.exception;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/EntityMetadata.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/EntityMetadata.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.metadata;
 
 import com.hpe.adm.nga.sdk.metadata.features.Feature;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/EntityMetadata.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/EntityMetadata.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.metadata;
 
 import com.hpe.adm.nga.sdk.metadata.features.Feature;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/FieldMetadata.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/FieldMetadata.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.metadata;
 
 import com.google.gson.annotations.SerializedName;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/FieldMetadata.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/FieldMetadata.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.metadata;
 
 import com.google.gson.annotations.SerializedName;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/GetEntityMetadata.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/GetEntityMetadata.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.metadata;
 
 import com.google.gson.Gson;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/GetEntityMetadata.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/GetEntityMetadata.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.metadata;
 
 import com.google.gson.Gson;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/GetFieldMetadata.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/GetFieldMetadata.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.metadata;
 
 import com.google.gson.Gson;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/GetFieldMetadata.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/GetFieldMetadata.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.metadata;
 
 import com.google.gson.Gson;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/Metadata.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/Metadata.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.metadata;
 
 import com.hpe.adm.nga.sdk.network.OctaneHttpClient;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/Metadata.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/Metadata.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.metadata;
 
 import com.hpe.adm.nga.sdk.network.OctaneHttpClient;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/MetadataOctaneRequest.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/MetadataOctaneRequest.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.metadata;
 
 import com.hpe.adm.nga.sdk.network.OctaneHttpClient;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/MetadataOctaneRequest.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/MetadataOctaneRequest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.metadata;
 
 import com.hpe.adm.nga.sdk.network.OctaneHttpClient;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/AttachmentsFeature.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/AttachmentsFeature.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.metadata.features;
 
 

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/AttachmentsFeature.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/AttachmentsFeature.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.metadata.features;
 
 

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/AuditingFeature.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/AuditingFeature.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.metadata.features;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/AuditingFeature.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/AuditingFeature.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.metadata.features;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/BusinessRulesFeature.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/BusinessRulesFeature.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.metadata.features;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/BusinessRulesFeature.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/BusinessRulesFeature.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.metadata.features;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/CommentsFeature.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/CommentsFeature.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.metadata.features;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/CommentsFeature.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/CommentsFeature.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.metadata.features;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/Feature.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/Feature.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.metadata.features;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/Feature.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/Feature.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.metadata.features;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/GroupingFeature.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/GroupingFeature.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.metadata.features;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/GroupingFeature.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/GroupingFeature.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.metadata.features;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/HierarchyFeature.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/HierarchyFeature.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.metadata.features;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/HierarchyFeature.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/HierarchyFeature.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.metadata.features;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/MailingFeature.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/MailingFeature.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.metadata.features;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/MailingFeature.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/MailingFeature.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.metadata.features;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/OrderingFeature.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/OrderingFeature.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.metadata.features;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/OrderingFeature.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/OrderingFeature.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.metadata.features;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/PhasesFeature.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/PhasesFeature.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.metadata.features;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/PhasesFeature.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/PhasesFeature.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.metadata.features;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/RestFeature.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/RestFeature.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.metadata.features;
 
 

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/RestFeature.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/RestFeature.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.metadata.features;
 
 

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/SubTypesFeature.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/SubTypesFeature.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.metadata.features;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/SubTypesFeature.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/SubTypesFeature.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.metadata.features;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/SubTypesOfFeature.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/SubTypesOfFeature.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.metadata.features;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/SubTypesOfFeature.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/SubTypesOfFeature.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.metadata.features;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/UdfFearture.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/UdfFearture.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.metadata.features;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/UdfFearture.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/features/UdfFearture.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.metadata.features;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/fieldfeatures/BusinessRules.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/fieldfeatures/BusinessRules.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.metadata.fieldfeatures;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/fieldfeatures/BusinessRules.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/metadata/fieldfeatures/BusinessRules.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.metadata.fieldfeatures;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/AllowedReferences.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/AllowedReferences.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.model;
 
 import java.lang.annotation.ElementType;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/AllowedReferences.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/AllowedReferences.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.model;
 
 import java.lang.annotation.ElementType;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/BooleanFieldModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/BooleanFieldModel.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.model;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/BooleanFieldModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/BooleanFieldModel.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.model;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/DateFieldModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/DateFieldModel.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.model;
 
 import java.time.ZoneId;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/DateFieldModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/DateFieldModel.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.model;
 
 import java.time.ZoneId;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/Entity.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/Entity.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.model;
 
 import javax.annotation.Nullable;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/Entity.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/Entity.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.model;
 
 import javax.annotation.Nullable;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/EntityMetadata.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/EntityMetadata.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.model;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/EntityMetadata.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/EntityMetadata.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.model;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/EntityModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/EntityModel.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.model;
 
 import java.util.Collection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/EntityModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/EntityModel.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.model;
 
 import java.util.Collection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/EntityUtil.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/EntityUtil.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.model;
 
 import java.util.*;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/ErrorModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/ErrorModel.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.model;
 
 import org.json.JSONObject;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/ErrorModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/ErrorModel.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.model;
 
 import org.json.JSONObject;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/FieldMetadata.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/FieldMetadata.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.model;
 
 import java.lang.annotation.ElementType;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/FieldMetadata.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/FieldMetadata.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.model;
 
 import java.lang.annotation.ElementType;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/FieldModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/FieldModel.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.model;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/FieldModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/FieldModel.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.model;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/FloatFieldModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/FloatFieldModel.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.model;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/FloatFieldModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/FloatFieldModel.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.model;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/LongFieldModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/LongFieldModel.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.model;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/LongFieldModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/LongFieldModel.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.model;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/ModelParser.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/ModelParser.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.model;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/ModelParser.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/ModelParser.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.model;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/MultiReferenceFieldModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/MultiReferenceFieldModel.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.model;
 
 import java.util.Collection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/MultiReferenceFieldModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/MultiReferenceFieldModel.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.model;
 
 import java.util.Collection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/ObjectFieldModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/ObjectFieldModel.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.model;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/ObjectFieldModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/ObjectFieldModel.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.model;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/OctaneCollectionImpl.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/OctaneCollectionImpl.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.model;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/OctaneCollectionImpl.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/OctaneCollectionImpl.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.model;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/OctaneCollectionSupplier.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/OctaneCollectionSupplier.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.model;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/OctaneCollectionSupplier.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/OctaneCollectionSupplier.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.model;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/ReferenceErrorModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/ReferenceErrorModel.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.model;
 
 

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/ReferenceErrorModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/ReferenceErrorModel.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.model;
 
 

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/ReferenceFieldModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/ReferenceFieldModel.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.model;
 
 

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/ReferenceFieldModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/ReferenceFieldModel.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.model;
 
 

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/StringFieldModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/StringFieldModel.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.model;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/StringFieldModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/StringFieldModel.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.model;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/TypedEntityModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/TypedEntityModel.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.model;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/TypedEntityModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/TypedEntityModel.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.model;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/network/OctaneHttpClient.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/network/OctaneHttpClient.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.network;
 
 import com.hpe.adm.nga.sdk.authentication.Authentication;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/network/OctaneHttpClient.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/network/OctaneHttpClient.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.network;
 
 import com.hpe.adm.nga.sdk.authentication.Authentication;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/network/OctaneHttpRequest.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/network/OctaneHttpRequest.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.network;
 
 import java.io.InputStream;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/network/OctaneHttpRequest.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/network/OctaneHttpRequest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.network;
 
 import java.io.InputStream;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/network/OctaneHttpResponse.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/network/OctaneHttpResponse.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.network;
 
 import com.google.api.client.util.IOUtils;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/network/OctaneHttpResponse.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/network/OctaneHttpResponse.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.network;
 
 import com.google.api.client.util.IOUtils;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/network/OctaneRequest.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/network/OctaneRequest.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.network;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/network/OctaneRequest.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/network/OctaneRequest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.network;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/network/OctaneUrl.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/network/OctaneUrl.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.network;
 
 

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/network/OctaneUrl.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/network/OctaneUrl.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.network;
 
 

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/network/google/GoogleHttpClient.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/network/google/GoogleHttpClient.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.network.google;
 
 import com.google.api.client.http.*;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/network/google/GoogleHttpClient.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/network/google/GoogleHttpClient.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.network.google;
 
 import com.google.api.client.http.*;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/query/Query.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/query/Query.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.query;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/query/Query.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/query/Query.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.query;
 
 /**

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/query/QueryMethod.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/query/QueryMethod.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.query;
 
 import java.text.SimpleDateFormat;

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/query/QueryMethod.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/query/QueryMethod.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.query;
 
 import java.text.SimpleDateFormat;

--- a/sdk-src/src/test/java/com/hpe/adm/nga/sdk/attachments/TestAttachments.java
+++ b/sdk-src/src/test/java/com/hpe/adm/nga/sdk/attachments/TestAttachments.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.attachments;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-src/src/test/java/com/hpe/adm/nga/sdk/attachments/TestAttachments.java
+++ b/sdk-src/src/test/java/com/hpe/adm/nga/sdk/attachments/TestAttachments.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.attachments;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-src/src/test/java/com/hpe/adm/nga/sdk/entities/TestCreateEntities.java
+++ b/sdk-src/src/test/java/com/hpe/adm/nga/sdk/entities/TestCreateEntities.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.entities;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-src/src/test/java/com/hpe/adm/nga/sdk/entities/TestCreateEntities.java
+++ b/sdk-src/src/test/java/com/hpe/adm/nga/sdk/entities/TestCreateEntities.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.entities;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-src/src/test/java/com/hpe/adm/nga/sdk/entities/TestUpdateEntities.java
+++ b/sdk-src/src/test/java/com/hpe/adm/nga/sdk/entities/TestUpdateEntities.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.entities;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-src/src/test/java/com/hpe/adm/nga/sdk/entities/TestUpdateEntities.java
+++ b/sdk-src/src/test/java/com/hpe/adm/nga/sdk/entities/TestUpdateEntities.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.entities;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-src/src/test/java/com/hpe/adm/nga/sdk/exception/TestOctaneExceptions.java
+++ b/sdk-src/src/test/java/com/hpe/adm/nga/sdk/exception/TestOctaneExceptions.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.exception;
 
 import com.hpe.adm.nga.sdk.model.*;

--- a/sdk-src/src/test/java/com/hpe/adm/nga/sdk/exception/TestOctaneExceptions.java
+++ b/sdk-src/src/test/java/com/hpe/adm/nga/sdk/exception/TestOctaneExceptions.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.exception;
 
 import com.hpe.adm.nga.sdk.model.*;

--- a/sdk-src/src/test/java/com/hpe/adm/nga/sdk/model/TestEntityUtil.java
+++ b/sdk-src/src/test/java/com/hpe/adm/nga/sdk/model/TestEntityUtil.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.model;
 
 import org.junit.Test;

--- a/sdk-src/src/test/java/com/hpe/adm/nga/sdk/model/TestModel.java
+++ b/sdk-src/src/test/java/com/hpe/adm/nga/sdk/model/TestModel.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.model;
 
 import org.json.JSONObject;

--- a/sdk-src/src/test/java/com/hpe/adm/nga/sdk/model/TestModel.java
+++ b/sdk-src/src/test/java/com/hpe/adm/nga/sdk/model/TestModel.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.model;
 
 import org.json.JSONObject;

--- a/sdk-src/src/test/java/com/hpe/adm/nga/sdk/model/TestQuery.java
+++ b/sdk-src/src/test/java/com/hpe/adm/nga/sdk/model/TestQuery.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.model;
 
 import com.hpe.adm.nga.sdk.query.Query;

--- a/sdk-src/src/test/java/com/hpe/adm/nga/sdk/model/TestQuery.java
+++ b/sdk-src/src/test/java/com/hpe/adm/nga/sdk/model/TestQuery.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.model;
 
 import com.hpe.adm.nga.sdk.query.Query;

--- a/sdk-src/src/test/java/com/hpe/adm/nga/sdk/network/TestOctaneUrl.java
+++ b/sdk-src/src/test/java/com/hpe/adm/nga/sdk/network/TestOctaneUrl.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.network;
 
 import com.hpe.adm.nga.sdk.unit_tests.common.CommonMethods;

--- a/sdk-src/src/test/java/com/hpe/adm/nga/sdk/network/TestOctaneUrl.java
+++ b/sdk-src/src/test/java/com/hpe/adm/nga/sdk/network/TestOctaneUrl.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.network;
 
 import com.hpe.adm.nga.sdk.unit_tests.common.CommonMethods;

--- a/sdk-src/src/test/java/com/hpe/adm/nga/sdk/network/google/TestGoogleHttpClient.java
+++ b/sdk-src/src/test/java/com/hpe/adm/nga/sdk/network/google/TestGoogleHttpClient.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.network.google;
 
 import com.google.api.client.http.HttpRequest;

--- a/sdk-src/src/test/java/com/hpe/adm/nga/sdk/network/google/TestGoogleHttpClient.java
+++ b/sdk-src/src/test/java/com/hpe/adm/nga/sdk/network/google/TestGoogleHttpClient.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.network.google;
 
 import com.google.api.client.http.HttpRequest;

--- a/sdk-src/src/test/java/com/hpe/adm/nga/sdk/query/TestQueryMethod.java
+++ b/sdk-src/src/test/java/com/hpe/adm/nga/sdk/query/TestQueryMethod.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.query;
 
 import org.junit.Assert;

--- a/sdk-src/src/test/java/com/hpe/adm/nga/sdk/unit_tests/common/CommonMethods.java
+++ b/sdk-src/src/test/java/com/hpe/adm/nga/sdk/unit_tests/common/CommonMethods.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.unit_tests.common;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-src/src/test/java/com/hpe/adm/nga/sdk/unit_tests/common/CommonMethods.java
+++ b/sdk-src/src/test/java/com/hpe/adm/nga/sdk/unit_tests/common/CommonMethods.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.unit_tests.common;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-src/src/test/java/com/hpe/adm/nga/sdk/unit_tests/common/CommonUtils.java
+++ b/sdk-src/src/test/java/com/hpe/adm/nga/sdk/unit_tests/common/CommonUtils.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.unit_tests.common;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-src/src/test/java/com/hpe/adm/nga/sdk/unit_tests/common/CommonUtils.java
+++ b/sdk-src/src/test/java/com/hpe/adm/nga/sdk/unit_tests/common/CommonUtils.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.unit_tests.common;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/sdk-usage-examples/pom.xml
+++ b/sdk-usage-examples/pom.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/sdk-usage-examples/pom.xml
+++ b/sdk-usage-examples/pom.xml
@@ -1,19 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/sdk-usage-examples/src/main/java/com/hpe/adm/nga/sdk/examples/CreateContextExample.java
+++ b/sdk-usage-examples/src/main/java/com/hpe/adm/nga/sdk/examples/CreateContextExample.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.examples;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-usage-examples/src/main/java/com/hpe/adm/nga/sdk/examples/CreateContextExample.java
+++ b/sdk-usage-examples/src/main/java/com/hpe/adm/nga/sdk/examples/CreateContextExample.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.examples;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-usage-examples/src/main/java/com/hpe/adm/nga/sdk/examples/EntityExample.java
+++ b/sdk-usage-examples/src/main/java/com/hpe/adm/nga/sdk/examples/EntityExample.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.examples;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-usage-examples/src/main/java/com/hpe/adm/nga/sdk/examples/EntityExample.java
+++ b/sdk-usage-examples/src/main/java/com/hpe/adm/nga/sdk/examples/EntityExample.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.examples;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-usage-examples/src/main/java/com/hpe/adm/nga/sdk/examples/MetadataExample.java
+++ b/sdk-usage-examples/src/main/java/com/hpe/adm/nga/sdk/examples/MetadataExample.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hpe.adm.nga.sdk.examples;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-usage-examples/src/main/java/com/hpe/adm/nga/sdk/examples/MetadataExample.java
+++ b/sdk-usage-examples/src/main/java/com/hpe/adm/nga/sdk/examples/MetadataExample.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.examples;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-usage-examples/src/main/java/com/hpe/adm/nga/sdk/examples/customhttpclient/DummyOctaneHttpClient.java
+++ b/sdk-usage-examples/src/main/java/com/hpe/adm/nga/sdk/examples/customhttpclient/DummyOctaneHttpClient.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.examples.customhttpclient;
 
 import com.hpe.adm.nga.sdk.authentication.Authentication;

--- a/sdk-usage-examples/src/main/java/com/hpe/adm/nga/sdk/examples/customhttpclient/DummyOctaneHttpClient.java
+++ b/sdk-usage-examples/src/main/java/com/hpe/adm/nga/sdk/examples/customhttpclient/DummyOctaneHttpClient.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.examples.customhttpclient;
 
 import com.hpe.adm.nga.sdk.authentication.Authentication;

--- a/sdk-usage-examples/src/main/java/com/hpe/adm/nga/sdk/examples/customhttpclient/DummyOctaneHttpClientExample.java
+++ b/sdk-usage-examples/src/main/java/com/hpe/adm/nga/sdk/examples/customhttpclient/DummyOctaneHttpClientExample.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hpe.adm.nga.sdk.examples.customhttpclient;
 
 import com.hpe.adm.nga.sdk.Octane;

--- a/sdk-usage-examples/src/main/java/com/hpe/adm/nga/sdk/examples/customhttpclient/DummyOctaneHttpClientExample.java
+++ b/sdk-usage-examples/src/main/java/com/hpe/adm/nga/sdk/examples/customhttpclient/DummyOctaneHttpClientExample.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hpe.adm.nga.sdk.examples.customhttpclient;
 
 import com.hpe.adm.nga.sdk.Octane;


### PR DESCRIPTION
See plugin part: https://github.com/MicroFocus/ALMOctaneJavaRESTSDK/compare/license-fix?expand=1#diff-600376dffeb79835ede4a0b285078036
All licenses updated.

Build will fail if license is missing from a file, it will also fail if the license is different from LICENSE.txt
![image](https://user-images.githubusercontent.com/23213115/51493333-b2f5fa00-1dbd-11e9-9f81-4fff50167075.png)

To fix it run.
`mvn com.mycila:license-maven-plugin:format` in the project root dir.
The license is added to all new filles from LICENSE.txt file.
Running this command will also update the license in all files.

If you'd like, we can make the build not fail by adding it into a profile.
We can then configure jenkins to mass update licenses on build, and commit+push the changes.