### PR TITLE
Fix entity id type inconsistency

### DIFF
--- a/sdk-generate-entity-models-maven-plugin/src/main/java/com/hpe/adm/nga/sdk/generate/GenerateModels.java
+++ b/sdk-generate-entity-models-maven-plugin/src/main/java/com/hpe/adm/nga/sdk/generate/GenerateModels.java
@@ -123,15 +123,6 @@ public class GenerateModels {
      */
     private boolean entityShouldNotBeGenerated(String name) {
         /*
-         * @Since 15.0.20
-         * The run_history's id is integer even though it should be string.  It would be extremely complicated to make a special case for run_history id as long
-         * Therefore until this is fixed in Octane - the entity will be ignored
-         */
-        if (name.equals("run_history")) {
-            return true;
-        }
-
-        /*
          * @Since 15.1.20
          * field_metadata is a special case in that it is used when defining UDFs.  It causes problems in the entity generation due to the list node
          * not having a reference.  It is unlikely that this would be used by the SDK so is ignored for now.  If this does cause an issue we could
@@ -141,21 +132,7 @@ public class GenerateModels {
             return true;
         }
 
-        /*
-         * @Since 15.1.20
-         * log entities have the ID marked as an integer and not as a string.  This causes issues with creating the entity.
-         * A defect has been raised in Octane to fix this
-         */
-        if (name.startsWith("log")) {
-            return true;
-        }
-
-        /*
-         * @Since 15.1.20
-         * This entity "overrides" the type field for its own use which causes issues.
-         * A defect has been raised in Octane to fix this
-         */
-        return name.equals("ci_parameter");
+        return false;
     }
 
     private Map<String, String> generateLists(Octane octane) throws IOException {
@@ -319,8 +296,14 @@ public class GenerateModels {
 
     private Collection<FieldMetadata> sanitiseMetaData(Collection<FieldMetadata> fieldMetadataCollection) {
         return fieldMetadataCollection.stream()
-                // filter out entities that have references without a target - like public to protected
+                // filter out fields that have references without a target - like public to protected
                 .filter(fieldMetadata -> fieldMetadata.getFieldType() != FieldMetadata.FieldType.Reference || fieldMetadata.getFieldTypedata().getTargets() != null)
+                // filter out fields that have references to field_metadata
+                .filter(fieldMetadata -> fieldMetadata.getFieldType() != FieldMetadata.FieldType.Reference || !fieldMetadata.getFieldTypedata().getTargets()[0].getType().startsWith("field_metadata"))
+                // filter out the id field, it is created automatically in the TypedEntityModel
+                .filter(fieldMetadata -> !fieldMetadata.getName().equals("id"))
+                // filter out the type field, it is created automatically in the TypedEntityModel, ci_parameter has a field called type that overrides id
+                .filter(fieldMetadata -> !fieldMetadata.getName().equals("type"))
                 .collect(Collectors.toList());
     }
 

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/manualtests/script/GetTestScriptModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/manualtests/script/GetTestScriptModel.java
@@ -38,12 +38,6 @@ public class GetTestScriptModel extends TypedEntityModel {
         super(wrappedEntityModel);
     }
 
-    @Nullable
-    @Override
-    public String getId() {
-        return null;
-    }
-
     /**
      * Label: Creation Time
      * Description: The date and time the script was created, according to the ISO-8601 date format.

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/manualtests/script/UpdateTestScriptModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/manualtests/script/UpdateTestScriptModel.java
@@ -26,12 +26,6 @@ import java.util.List;
  */
 public final class UpdateTestScriptModel extends TypedEntityModel {
 
-    @Nullable
-    @Override
-    public String getId() {
-        return null;
-    }
-
     /**
      * Represents the revision type (see Octane test script documentation)
      */

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/TypedEntityModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/TypedEntityModel.java
@@ -49,11 +49,22 @@ public abstract class TypedEntityModel implements Entity {
     }
 
     /**
+     * Returns the id of this entity
+     * @return The entity id
+     */
+    @Override
+    public final String getId() {
+        FieldModel<?> id = wrappedEntityModel.getValue("id");
+        return id == null ? null : id.getValue().toString();
+    }
+
+    /**
      * Returns the type of this entity
      * @return The entity type
      */
     @Override
     public final String getType() {
-        return ((StringFieldModel) wrappedEntityModel.getValue("type")).getValue();
+        FieldModel<?> id = wrappedEntityModel.getValue("type");
+        return id == null ? null : id.getValue().toString();
     }
 }

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/TypedEntityModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/TypedEntityModel.java
@@ -64,7 +64,7 @@ public abstract class TypedEntityModel implements Entity {
      */
     @Override
     public final String getType() {
-        FieldModel<?> id = wrappedEntityModel.getValue("type");
-        return id == null ? null : id.getValue().toString();
+        FieldModel<?> type = wrappedEntityModel.getValue("type");
+        return type == null ? null : type.getValue().toString();
     }
 }


### PR DESCRIPTION
- created final getId method in TypedEntityModel, and removed getId methods from GetTestScriptModel and UpdateTestScriptModel, to fix inconsistencies between id types
- removed skipping of entities that had Id of type Long (Octane: Integer/Number)
- removed method creation for fields of type "field_metadata", FieldMetadataEntityModel is skipped
- removed method creation for fields with name "id" and "type", "id" and "type" methods are created in TypedEntityModel