### PR TITLE
added case for required multi reference list_node

### DIFF
--- a/sdk-generate-entity-models-maven-plugin/src/main/java/com/hpe/adm/nga/sdk/generate/GenerateModels.java
+++ b/sdk-generate-entity-models-maven-plugin/src/main/java/com/hpe/adm/nga/sdk/generate/GenerateModels.java
@@ -266,7 +266,11 @@ public class GenerateModels {
                     } else if (fieldMetadata1.getFieldType() == FieldMetadata.FieldType.Reference) {
                         if ((!entityMetadatum.getName().equals("list_node")) && (fieldMetadata1.getFieldTypedata().getTargets()[0].getType().equals("list_node"))) {
                             final String listName = logicalNameToListsMap.get(fieldMetadata1.getFieldTypedata().getTargets()[0].logicalName());
-                            references.add(listName);
+                            if (fieldMetadata1.getFieldTypedata().isMultiple()) {
+                                references.add("java.util.Collection<" + listName + ">");
+                            } else {
+                                references.add(listName);
+                            }
                         } else {
                             final GeneratorHelper.ReferenceMetadata referenceMetadata = GeneratorHelper.getAllowedSuperTypesForReference(fieldMetadata1, entityMetadata);
                             if (fieldMetadata1.getFieldTypedata().isMultiple()) {


### PR DESCRIPTION
the entity scm_repository_pattern has a required field "applied_to" that is of type multireference list node, type that wasn't handled for constructor creation