### PR TITLE
bump google-api-client version from 1.30.2 to 1.31.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <slf4j.version>1.7.25</slf4j.version>
         <logback.version>1.1.3</logback.version>
 
-        <google-api-client.version>1.30.2</google-api-client.version>
+        <google-api-client.version>1.31.1</google-api-client.version>
         <org-json.version>20160212</org-json.version>
 
         <commons-configuration.version>2.0</commons-configuration.version>


### PR DESCRIPTION
Increased the version of google-api-client to one that supports com.google.api.client.http.apache.v2.ApacheHttpTransport