### PR TITLE
- update GenerateModels:

### DIFF
--- a/sdk-generate-entity-models-maven-plugin/src/main/java/com/hpe/adm/nga/sdk/generate/GenerateModels.java
+++ b/sdk-generate-entity-models-maven-plugin/src/main/java/com/hpe/adm/nga/sdk/generate/GenerateModels.java
@@ -215,6 +215,7 @@ public class GenerateModels {
                     .replaceAll(" ", "_")
                     .replaceAll("&", "N")
                     .replaceAll("/", "_")
+                    .replaceAll("-", "_")
                     .toUpperCase()});
             phaseMap.merge(GeneratorHelper.camelCaseFieldName(((StringFieldModel) phase.getValue("entity")).getValue(), true), phaseValueSet, (existingValues, newValues) -> {
                 existingValues.addAll(newValues);


### PR DESCRIPTION
  * an admin can use "-" in a phase name, e.g. SHELF-READY. this result in an invalid enum name. replace "-" with
    "_". ideally the back-end should limit names.