### PR TITLE
Removed apache-common-configuration dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 <dependency>
     <groupId>com.microfocus.adm.almoctane.sdk</groupId>
     <artifactId>sdk-src</artifactId>
-    <version>16.0.400.1</version>
+    <version>16.1.100</version>
 </dependency>
 ```
 #### Gradle
 ```groovy
-compile group: 'com.microfocus.adm.almoctane.sdk', name: 'sdk-src', version: '16.0.400.1'
+compile group: 'com.microfocus.adm.almoctane.sdk', name: 'sdk-src', version: '16.1.100'
 ```
 
 ## Introduction
@@ -51,7 +51,7 @@ This plugin connects to your ALM Octane server using the given authentication cr
 and generates strongly typed entities that can be used instead of the generic out of the box entity that comes
 with the SDK.
 
-To enable this, add the following to your project's POM file (assuming 16.0.400.1 being the SDK version):
+To enable this, add the following to your project's POM file (assuming 16.1.100 being the SDK version):
 
 ```xml
  <build>
@@ -59,7 +59,7 @@ To enable this, add the following to your project's POM file (assuming 16.0.400.
             <plugin>
                 <groupId>com.microfocus.adm.almoctane.sdk</groupId>
                 <artifactId>sdk-generate-entity-models-maven-plugin</artifactId>
-                <version>16.0.400.1</version>
+                <version>16.1.100</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>
@@ -171,7 +171,7 @@ The easiest way is to add a maven dependency to such an implementation (slf4j-si
         <dependency>
             <groupId>com.microfocus.adm.almoctane.sdk</groupId>
             <artifactId>sdk-src</artifactId>
-            <version>16.0.400.1</version>
+            <version>16.1.100</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -189,6 +189,8 @@ spaces can be accessed.  See the `TestSharedSpaceAdmin` and `TestWorkSpaceAdmin`
 Currently the admin sections are not available using generated entities - but the CRUD functions are available
 
 ## What's New
+* 16.1.100
+  * Fixed vulnerability by removing transitive dependency for apache-commons-text
 * 16.0.400.1
   * Fixed bug related to session cookie collision on parallel requests
 * 16.0.400

--- a/pom.xml
+++ b/pom.xml
@@ -71,9 +71,8 @@
         <google-api-client.version>1.42.0</google-api-client.version>
         <org-json.version>20160212</org-json.version>
 
-        <commons-configuration.version>2.0</commons-configuration.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
-        <commons-io.version>2.7</commons-io.version>
+        <commons-io.version>2.11.0</commons-io.version>
         <commons-lang3>3.12.0</commons-lang3>
 
         <maven-release.version>2.5.3</maven-release.version>
@@ -124,11 +123,6 @@
                 <groupId>org.json</groupId>
                 <artifactId>json</artifactId>
                 <version>${org-json.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-configuration2</artifactId>
-                <version>${commons-configuration.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-beanutils</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>com.microfocus.adm.almoctane.sdk</groupId>
     <artifactId>sdk-root</artifactId>
     <packaging>pom</packaging>
-    <version>16.0.400.1-SNAPSHOT</version>
+    <version>16.1.100-SNAPSHOT</version>
 
     <name>ALM Octane REST API SDK</name>
     <description>The Java SDK that can be used to access Octane's REST API without worrying about REST or HTTP

--- a/sdk-extension/pom.xml
+++ b/sdk-extension/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>sdk-root</artifactId>
         <groupId>com.microfocus.adm.almoctane.sdk</groupId>
-        <version>16.0.400.1-SNAPSHOT</version>
+        <version>16.1.100-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sdk-extension/sdk-extension-src/pom.xml
+++ b/sdk-extension/sdk-extension-src/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
         <groupId>com.microfocus.adm.almoctane.sdk.extension</groupId>
         <artifactId>sdk-extension-root</artifactId>
-        <version>16.0.400.1-SNAPSHOT</version>
+        <version>16.1.100-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/sdk-extension/sdk-extension-usage-examples/pom.xml
+++ b/sdk-extension/sdk-extension-usage-examples/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
         <groupId>com.microfocus.adm.almoctane.sdk.extension</groupId>
         <artifactId>sdk-extension-root</artifactId>
-        <version>16.0.400.1-SNAPSHOT</version>
+        <version>16.1.100-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/sdk-generate-entity-models-maven-plugin/pom.xml
+++ b/sdk-generate-entity-models-maven-plugin/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>sdk-root</artifactId>
         <groupId>com.microfocus.adm.almoctane.sdk</groupId>
-        <version>16.0.400.1-SNAPSHOT</version>
+        <version>16.1.100-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>maven-plugin</packaging>

--- a/sdk-integration-tests/pom.xml
+++ b/sdk-integration-tests/pom.xml
@@ -33,11 +33,6 @@
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-configuration2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
             <scope>test</scope>

--- a/sdk-integration-tests/pom.xml
+++ b/sdk-integration-tests/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>sdk-root</artifactId>
         <groupId>com.microfocus.adm.almoctane.sdk</groupId>
-        <version>16.0.400.1-SNAPSHOT</version>
+        <version>16.1.100-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/ConfigurationUtils.java
+++ b/sdk-integration-tests/src/test/java/com/hpe/adm/nga/sdk/utils/ConfigurationUtils.java
@@ -13,10 +13,8 @@
  */
 package com.hpe.adm.nga.sdk.utils;
 
-import org.apache.commons.configuration2.CombinedConfiguration;
-import org.apache.commons.configuration2.SystemConfiguration;
-import org.apache.commons.configuration2.builder.fluent.Configurations;
-import org.apache.commons.configuration2.ex.ConfigurationException;
+import java.io.IOException;
+import java.util.Properties;
 
 /**
  *
@@ -25,15 +23,14 @@ import org.apache.commons.configuration2.ex.ConfigurationException;
 public class ConfigurationUtils {
 	private static final ConfigurationUtils INSTANCE = new ConfigurationUtils();
 
-	final CombinedConfiguration combinedConfiguration;
+	final Properties combinedConfiguration;
 
 	private ConfigurationUtils() {
-		final Configurations configurations = new Configurations();
-		combinedConfiguration = new CombinedConfiguration();
 		try {
-			combinedConfiguration.addConfiguration(new SystemConfiguration());
-			combinedConfiguration.addConfiguration(configurations.properties("configuration.properties"));
-		} catch (ConfigurationException e) {
+			combinedConfiguration = System.getProperties();
+			combinedConfiguration.load(Thread.currentThread().getContextClassLoader()
+					.getResourceAsStream("configuration.properties"));
+		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
 	}
@@ -43,6 +40,6 @@ public class ConfigurationUtils {
 	}
 
 	public final String getString(final String property) {
-		return combinedConfiguration.getString(property);
+		return combinedConfiguration.getProperty(property);
 	}
 }

--- a/sdk-src/pom.xml
+++ b/sdk-src/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>sdk-root</artifactId>
         <groupId>com.microfocus.adm.almoctane.sdk</groupId>
-        <version>16.0.400.1-SNAPSHOT</version>
+        <version>16.1.100-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sdk-usage-examples/pom.xml
+++ b/sdk-usage-examples/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>sdk-root</artifactId>
         <groupId>com.microfocus.adm.almoctane.sdk</groupId>
-        <version>16.0.400.1-SNAPSHOT</version>
+        <version>16.1.100-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Apache-common-configuration had a transitive dependency for octane-common-text. This library was only used in tests for loading configuration from the system and config file, so we've replaced it with java.util