### PR TITLE
ModelParser: improve parsing of date fields

### DIFF
--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/ModelParser.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/ModelParser.java
@@ -14,6 +14,7 @@
 package com.hpe.adm.nga.sdk.model;
 
 import com.hpe.adm.nga.sdk.entities.OctaneCollection;
+import java.time.format.DateTimeParseException;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.json.JSONTokener;
@@ -29,7 +30,6 @@ public final class ModelParser {
     private static final String JSON_ERRORS_NAME = "errors";
     private static final String JSON_TOTAL_COUNT_NAME = "total_count";
     private static final String JSON_EXCEEDS_TOTAL_COUNT_NAME = "exceeds_total_count";
-    private static final String REGEX_DATE_FORMAT = "\\d{4}-\\d{1,2}-\\d{1,2}T\\d{1,2}:\\d{1,2}:\\d{1,2}Z";
     private static final String LOGGER_INVALID_FIELD_SCHEME_FORMAT = "{} field scheme is invalid";
 
     private final Logger logger = LoggerFactory.getLogger(ModelParser.class.getName());
@@ -174,15 +174,13 @@ public final class ModelParser {
 
             } else if (aObj instanceof String) {
 
-                boolean isMatch = aObj.toString().matches(REGEX_DATE_FORMAT);
-                if (isMatch) {
-
-                    final ZonedDateTime zonedDateTime = ZonedDateTime.parse(aObj.toString());
+                try {
+                    ZonedDateTime zonedDateTime = ZonedDateTime.parse(aObj.toString());
                     fldModel = new DateFieldModel(strKey, zonedDateTime);
-
-                } else {
+                } catch (DateTimeParseException e) {
                     fldModel = new StringFieldModel(strKey, aObj.toString());
                 }
+
             } else {
                 logger.debug(LOGGER_INVALID_FIELD_SCHEME_FORMAT, strKey);
                 continue; //do not put it inside the model object to avoid a null pointer exception

--- a/sdk-src/src/test/java/com/hpe/adm/nga/sdk/model/TestModel.java
+++ b/sdk-src/src/test/java/com/hpe/adm/nga/sdk/model/TestModel.java
@@ -23,6 +23,8 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.*;
 
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -139,7 +141,7 @@ public class TestModel {
     }
 
     @Test
-    public void testEntityModelWithDateField() {
+    public void testEntityModelWithDateField_fromModelToJsonObject() {
         ZonedDateTime now = ZonedDateTime.now().withZoneSameInstant(ZoneId.of("Z"));
         expectedResult = "{\"field\":\"" + now.toString() + "\"}";
         set.add(new DateFieldModel("field", now));
@@ -150,6 +152,26 @@ public class TestModel {
         } catch (Exception ex) {
             fail("Failed with exception: " + ex);
         }
+    }
+
+    @Test
+    public void testEntityModelWithDateField_fromJsonObjectToModel_dateWithMillis() {
+        JSONObject jsonObject = new JSONObject("{\"creation_time\":\"2022-09-07T14:26:44.143Z\"}");
+
+        EntityModel entityModel = ModelParser.getInstance().getEntityModel(jsonObject);
+        FieldModel dateField = entityModel.getValue("creation_time");
+
+        assertThat(dateField.getValue(), instanceOf(ZonedDateTime.class));
+    }
+
+    @Test
+    public void testEntityModelWithDateField_fromJsonObjectToModel_dateWithoutMillis() {
+        JSONObject jsonObject = new JSONObject("{\"creation_time\":\"2022-09-07T14:26:44Z\"}");
+
+        EntityModel entityModel = ModelParser.getInstance().getEntityModel(jsonObject);
+        FieldModel dateField = entityModel.getValue("creation_time");
+
+        assertThat(dateField.getValue(), instanceOf(ZonedDateTime.class));
     }
 
     @Test


### PR DESCRIPTION
Rather than first matching the string against a regex and then parsing it wiht ZonedDateTime.parse(), just parse it, and fallback to StringFieldModel if that does not work.

This is more flexible.
For example, perfectly valid dates with millis like '2022-09-07T14:26:44.143Z', were previously being converted to StringFieldModel, because the regex was not considering millis.