### PR TITLE
make GenerateModels smarter when replacing illegal characters

### DIFF
--- a/sdk-generate-entity-models-maven-plugin/src/main/java/com/hpe/adm/nga/sdk/generate/GenerateModels.java
+++ b/sdk-generate-entity-models-maven-plugin/src/main/java/com/hpe/adm/nga/sdk/generate/GenerateModels.java
@@ -224,12 +224,8 @@ public class GenerateModels {
         final Collection<EntityModel> phases = octane.entityList("phases").get().addFields("id", "name", "entity").execute();
         phases.forEach(phase -> {
             final Set<String[]> phaseValueSet = new HashSet<>();
-            phaseValueSet.add(new String[]{phase.getId(), ((StringFieldModel) phase.getValue("name")).getValue()
-                    .replaceAll(" ", "_")
-                    .replaceAll("&", "N")
-                    .replaceAll("/", "_")
-                    .replaceAll("-", "_")
-                    .toUpperCase()});
+
+            phaseValueSet.add(new String[]{phase.getId(), createIdentifier(((StringFieldModel) phase.getValue("name")).getValue())});
             phaseMap.merge(GeneratorHelper.camelCaseFieldName(((StringFieldModel) phase.getValue("entity")).getValue(), true), phaseValueSet, (existingValues, newValues) -> {
                 existingValues.addAll(newValues);
                 return existingValues;
@@ -403,5 +399,24 @@ public class GenerateModels {
 
             entityListFileWriter.close();
         }
+    }
+
+    private String createIdentifier(final String phaseValue) {
+        if (phaseValue == null || phaseValue.length() == 0) {
+            return "_";
+        }
+
+        final char[] c = phaseValue.toCharArray();
+        if (!Character.isJavaIdentifierStart(c[0])) {
+            c[0] = '_';
+        }
+
+        for (int i = 1; i < c.length; i++) {
+            if (!Character.isJavaIdentifierPart(c[i])) {
+                c[i] = '_';
+            }
+        }
+
+        return new String(c).toUpperCase();
     }
 }


### PR DESCRIPTION
The hard coded list has to be extended from time to time. Rather check for invalid chars using java.lang.Character and replace it with '_' as before. This should reduce the need to update the list.

See also PR #143 as well as #125 for previous fixes.